### PR TITLE
fix(style):Removes the float from the checkbox

### DIFF
--- a/SimplePHPForm.php
+++ b/SimplePHPForm.php
@@ -205,7 +205,7 @@ class SimplePHPForm
 			}
 			else if($type == 'checkbox') // Check box. Never needs an error message. Will never need an error or info message.
 			{
-				$output .= '<div class="simplephpform_title"></div><div style="float: left; margin-bottom: 2px;">'."\n";
+				$output .= '<div class="simplephpform_title"></div><div style="">'."\n";
 
 				if(boolval($this->input_list[$name]->data))
 					$output .= '<label><input type="'.$this->input_list[$name]->type.'" name="simplephpform_'.$this->input_list[$name]->name.'" checked="checked" />'.$this->input_list[$name]->text_title."</label>\n";


### PR DESCRIPTION
The float on the checkbox is not necessary. This is the only output with style hard coded. Removing the hard coded style will keep the checkbox more in line with the other outputs and allow the user to more easily make changes.